### PR TITLE
Add theme switching with Provider and ThemeProvider

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,22 +1,59 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart'; // 1. Import provider
+import 'theme_provider.dart';         // 2. Import your ThemeProvider (ensure this path is correct)
 import 'screens/welcome_screen.dart';
-import 'screens/verification_screen.dart';
+// If VerificationScreen here is different from lib/screens/verification_screen.dart, ensure consistent usage
+// import 'screens/verification_screen.dart'; // This would be the typical import
 
-void main() {
-  runApp(MyApp());
+void main() async { // 3. Make main async
+  WidgetsFlutterBinding.ensureInitialized(); // 4. Ensure bindings are initialized
+  runApp(
+    ChangeNotifierProvider( // 5. Provide ThemeProvider
+      create: (_) => ThemeProvider(),
+      child: MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
+  // Removed const from MyApp to allow hot reload with provider changes if needed,
+  // but can be const if child widgets handle all state.
   @override
   Widget build(BuildContext context) {
+    // 6. Get ThemeProvider instance
+    final themeProvider = Provider.of<ThemeProvider>(context);
+
     return MaterialApp(
       title: 'Washio',
-      theme: ThemeData(
+      // 7. Apply theme settings from ThemeProvider
+      themeMode: themeProvider.themeMode,
+      theme: ThemeData( // Your Light Theme
         primarySwatch: Colors.blue,
+        brightness: Brightness.light,
+        // Add other light theme specific properties here
+        // Example:
+        // scaffoldBackgroundColor: Colors.white,
+        // appBarTheme: AppBarTheme(backgroundColor: Colors.blue, foregroundColor: Colors.white),
+      ),
+      darkTheme: ThemeData( // Your Dark Theme
+        primarySwatch: Colors.blue, // Or a different swatch for dark mode
+        brightness: Brightness.dark,
+        // Add other dark theme specific properties here
+        // Example:
+        // scaffoldBackgroundColor: Colors.grey[900],
+        // appBarTheme: AppBarTheme(backgroundColor: Colors.grey[850], foregroundColor: Colors.white),
+        // elevatedButtonTheme: ElevatedButtonThemeData(
+        //   style: ElevatedButton.styleFrom(
+        //     backgroundColor: Colors.blue[700],
+        //     foregroundColor: Colors.white,
+        //   ),
+        // ),
       ),
       initialRoute: '/',
       routes: {
         '/': (context) => WelcomeScreen(),
+        // This VerificationScreen is the one defined below in this file.
+        // If you have one in lib/screens/, ensure you're using the correct one.
         '/verification': (context) => VerificationScreen(
           phoneNumber: ModalRoute.of(context)!.settings.arguments as String,
         ),
@@ -26,6 +63,9 @@ class MyApp extends StatelessWidget {
   }
 }
 
+// This VerificationScreen is defined in your main.dart.
+// If you have a more up-to-date version in lib/screens/verification_screen.dart,
+// you might want to remove this one and import the other.
 class VerificationScreen extends StatelessWidget {
   final String phoneNumber;
 
@@ -61,40 +101,16 @@ class VerificationScreen extends StatelessWidget {
             SizedBox(height: 20),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                Container(
-                  width: 50,
-                  child: TextField(
-                    decoration: InputDecoration(
-                      border: OutlineInputBorder(),
-                    ),
+              children: List.generate(4, (index) => // Assuming 4 digits for this example
+              Container(
+                width: 50,
+                child: TextField(
+                  decoration: InputDecoration(
+                    border: OutlineInputBorder(),
                   ),
                 ),
-                Container(
-                  width: 50,
-                  child: TextField(
-                    decoration: InputDecoration(
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                ),
-                Container(
-                  width: 50,
-                  child: TextField(
-                    decoration: InputDecoration(
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                ),
-                Container(
-                  width: 50,
-                  child: TextField(
-                    decoration: InputDecoration(
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                ),
-              ],
+              ),
+              ),
             ),
             SizedBox(height: 20),
             Center(

--- a/lib/screens/edit_profile_screen.dart
+++ b/lib/screens/edit_profile_screen.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
-import '../api.dart'; // For ApiService.updateUserDetails
+import 'package:provider/provider.dart'; // Import Provider
+import '../theme_provider.dart'; // Assuming theme_provider.dart is in lib/
+import '../api.dart'; 
 
 class EditProfileScreen extends StatefulWidget {
-  final Map<String, dynamic> userData; // Expecting user data map
+  final Map<String, dynamic> userData;
 
-  // Simplified constructor, only takes userData
   const EditProfileScreen({Key? key, required this.userData}) : super(key: key);
 
   @override
@@ -20,6 +21,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   int? _userId;
 
   bool _isLoading = false;
+  // bool _isDarkModeEnabled = false; // Removed: state now managed by ThemeProvider
 
   @override
   void initState() {
@@ -32,6 +34,9 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     
     String phone = widget.userData['phone']?.toString() ?? ''; 
     _displayPhone = phone; 
+
+    // No need to initialize _isDarkModeEnabled here from ThemeProvider for the build method,
+    // as Provider.of(context) in build will provide the current state.
   }
 
   Future<void> _saveChanges() async {
@@ -93,9 +98,22 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // Get the current theme provider
+    final themeProvider = Provider.of<ThemeProvider>(context);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Edit Profile'),
+        actions: [
+          IconButton(
+            icon: Icon(themeProvider.isDarkMode ? Icons.light_mode : Icons.dark_mode),
+            tooltip: themeProvider.isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode',
+            onPressed: () {
+              // Toggle theme using the provider
+              themeProvider.toggleTheme();
+            },
+          ),
+        ],
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
@@ -175,7 +193,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 onPressed: _isLoading ? null : _saveChanges,
                 child: _isLoading
                     ? const CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white))
-                    : const Text('Save Changes'), // fontSize is handled by the style
+                    : const Text('Save Changes'), 
               ),
             ],
           ),

--- a/lib/theme_provider.dart
+++ b/lib/theme_provider.dart
@@ -1,0 +1,47 @@
+// lib/theme_provider.dart
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeProvider with ChangeNotifier {
+  static const String _themeModeKey = 'themeMode';
+  ThemeMode _themeMode = ThemeMode.light; // Default theme
+
+  ThemeMode get themeMode => _themeMode;
+
+  bool get isDarkMode => _themeMode == ThemeMode.dark;
+
+  ThemeProvider() {
+    _loadThemeMode();
+  }
+
+  Future<void> _loadThemeMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final savedThemeMode = prefs.getString(_themeModeKey);
+    if (savedThemeMode == 'dark') {
+      _themeMode = ThemeMode.dark;
+    } else if (savedThemeMode == 'system') {
+      _themeMode = ThemeMode.system;
+    } else {
+      _themeMode = ThemeMode.light;
+    }
+    notifyListeners();
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    if (_themeMode == mode) return;
+    _themeMode = mode;
+    final prefs = await SharedPreferences.getInstance();
+    if (mode == ThemeMode.dark) {
+      await prefs.setString(_themeModeKey, 'dark');
+    } else if (mode == ThemeMode.system) {
+      await prefs.setString(_themeModeKey, 'system');
+    } else {
+      await prefs.setString(_themeModeKey, 'light');
+    }
+    notifyListeners();
+  }
+
+  void toggleTheme() {
+    setThemeMode(isDarkMode ? ThemeMode.light : ThemeMode.dark);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -280,6 +280,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -344,6 +352,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,10 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.8
   http: ^1.2.0
-  shared_preferences: ^2.2.2
   country_code_picker: ^3.0.0
+  provider: ^6.1.1
+  shared_preferences: ^2.2.2
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Introduced ThemeProvider for managing light/dark theme using Provider and shared_preferences. Updated main.dart and edit_profile_screen.dart to support theme switching, and added provider dependency to pubspec.yaml. Users can now toggle between light and dark modes from the Edit Profile screen.