### PR TITLE
Add otpPurpose to verification and welcome screens

### DIFF
--- a/lib/screens/verification_screen.dart
+++ b/lib/screens/verification_screen.dart
@@ -8,12 +8,14 @@ class VerificationScreen extends StatefulWidget {
   final String phoneNumber; 
   final String countryCode; 
   final String countryName;
+  final String otpPurpose; // <<< NEW: Added otpPurpose field
 
   const VerificationScreen({
     Key? key,
     required this.phoneNumber,
     required this.countryCode,
     required this.countryName,
+    required this.otpPurpose, // <<< NEW: Added otpPurpose to constructor
   }) : super(key: key);
 
   @override
@@ -54,7 +56,8 @@ class _VerificationScreenState extends State<VerificationScreen> {
     });
 
     try {
-      final response = await ApiService.verifyOtp(widget.countryCode, widget.phoneNumber, otp);
+      // Pass widget.otpPurpose to ApiService.verifyOtp
+      final response = await ApiService.verifyOtp(widget.countryCode, widget.phoneNumber, otp, widget.otpPurpose); // <<< MODIFIED
 
       if (mounted) {
         if (response['status'] == 'success') {
@@ -154,11 +157,17 @@ class _VerificationScreenState extends State<VerificationScreen> {
       _isLoading = true; 
     });
     try {
-      await ApiService.requestOtp(widget.phoneNumber, widget.countryCode);
+      // Note: requestOtp now returns a map that includes 'otp_purpose'
+      // For resend, we are not directly using the new otp_purpose in this screen's state,
+      // as this screen was initialized with an otpPurpose. This might be a point of future refinement
+      // if the purpose can change dynamically upon resend.
+      final Map<String, dynamic> newOtpResponse = await ApiService.requestOtp(widget.phoneNumber, widget.countryCode);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('A new OTP has been sent to your phone number.')),
+          SnackBar(content: Text(newOtpResponse['message'] ?? 'A new OTP has been sent.')),
         );
+         // Potentially, if otp_purpose changed upon resend, you might need to update widget.otpPurpose
+        // or inform the user. For now, this screen will continue to use the otpPurpose it was initialized with.
       }
     } catch (e) {
       if (mounted) {
@@ -187,7 +196,7 @@ class _VerificationScreenState extends State<VerificationScreen> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Text(
-              'Enter the 6-digit code sent to ${widget.countryCode}${widget.phoneNumber}.',
+              'Enter the 6-digit code sent to ${widget.countryCode}${widget.phoneNumber}. Purpose: ${widget.otpPurpose}', // Displaying otpPurpose for clarity
               style: const TextStyle(fontSize: 16),
               textAlign: TextAlign.center,
             ),

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -111,6 +111,9 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
       final response = await ApiService.requestOtp(phoneInput, currentSelectedDialCode);
       if (mounted) {
         if (response['status'] == 'success') {
+          // <<< NEW: Extract otp_purpose from the response
+          String otpPurpose = response['otp_purpose'] as String? ?? 'login'; // Default to 'login' if not present
+
           Navigator.push(
             context,
             MaterialPageRoute(
@@ -118,6 +121,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                 phoneNumber: phoneInput,
                 countryCode: currentSelectedDialCode,
                 countryName: _selectedCountryName,
+                otpPurpose: otpPurpose, // <<< NEW: Pass otpPurpose here
               ),
             ),
           );
@@ -193,12 +197,6 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                   searchStyle: TextStyle(color: theme.colorScheme.onSurface), // For text typed in search
                   flagDecoration: BoxDecoration(borderRadius: BorderRadius.circular(2)),
                   boxDecoration: BoxDecoration(color: Colors.transparent), // To prevent potential conflict
-                  // It seems the icon color for the dropdown arrow within CountryCodePicker
-                  // might need more direct styling or might be using an internal Icon widget.
-                  // If it doesn't change, this might be a limitation of the package's direct styling options.
-                  // We can try setting a general iconTheme for the picker if available,
-                  // or wrap it in a Theme widget if deeply needed.
-                  // For now, let's assume the text and background changes will be the most impactful.
                 ),
                 const SizedBox(width: 5),
                 Expanded(


### PR DESCRIPTION
Introduces the otpPurpose field to VerificationScreen and passes it through from WelcomeScreen after OTP request. Updates API calls to include otpPurpose and displays it for user clarity. This change supports handling different OTP purposes and improves context for verification flows.