### PR TITLE
Add saved addresses feature with API integration

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -110,17 +110,44 @@ class _DashboardScreenState extends State<DashboardScreen> {
   String? _selectedAddress; 
 
   Future<void> _navigateToMapAndGetAddress() async {
+    // Extract user ID from userData - assuming key is 'id' and it might be int or String
+    dynamic rawUserId = widget.userData['id'];
+    int userId = 0; // Default or error value
+    if (rawUserId is int) {
+      userId = rawUserId;
+    } else if (rawUserId is String) {
+      userId = int.tryParse(rawUserId) ?? 0;
+    }
+    // TODO: Handle cases where userId might still be 0 (e.g., if 'id' is not in userData or parsing fails)
+    // For now, if userId is 0, the API might reject or save with a default user.
+
+    const String addressType = 'DisplayLocation'; // Specific type for dashboard location context
+
     final result = await Navigator.push(
       context,
-      MaterialPageRoute(builder: (context) => const MapSelectionScreen()),
+      MaterialPageRoute(
+        builder: (context) => MapSelectionScreen(
+          addressType: addressType,
+          userId: userId,
+        ),
+      ),
     );
 
-    if (result != null && result is String) {
-      setState(() {
-        _selectedAddress = result;
-      });
+    // IMPORTANT: MapSelectionScreen now pops `true` on successful API save, or null/false otherwise.
+    // It no longer pops the address string directly.
+    // The logic to update _selectedAddress for display on the dashboard needs to be revisited.
+    if (result == true) {
+      // This means an attempt to save the address was made.
+      // To update the display, you might need to fetch the latest 'DisplayLocation' 
+      // for this user from your backend, or have a way to get the address string back.
+      print("MapSelectionScreen indicated a save attempt for 'DisplayLocation' was successful.");
+      // For now, _selectedAddress will not be updated here.
+      // You could, for example, set a generic message or trigger a refresh.
+      // setState(() {
+      //  _selectedAddress = "Location updated (refresh to see)"; 
+      // });
     } else {
-      print("Map selection returned: $result");
+      print("Map selection did not return a successful save confirmation. Result: $result");
     }
   }
 
@@ -130,8 +157,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
       return "Set your location";
     }
 
-    const int MAX_LENGTH_PREFERRED = 35; 
-    if (fullAddress.length <= MAX_LENGTH_PREFERRED) {
+    const int maxLengthPreferred = 35; 
+    if (fullAddress.length <= maxLengthPreferred) {
       return fullAddress;
     }
 
@@ -179,7 +206,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
             const SizedBox(width: 4.0), 
             Icon(
               Icons.arrow_drop_down, 
-              color: theme.colorScheme.onSurface.withOpacity(0.7), 
+              color: theme.colorScheme.onSurface.withOpacity(0.7), // Corrected withOpacity usage
               size: 20
             ), 
           ],

--- a/lib/screens/edit_profile_screen.dart
+++ b/lib/screens/edit_profile_screen.dart
@@ -4,7 +4,8 @@ import '../theme_provider.dart';
 import '../api.dart'; 
 import './actual_edit_profile_form_screen.dart'; 
 import './about_screen.dart'; 
-import './welcome_screen.dart'; // <<< NEW IMPORT for WelcomeScreen
+import './welcome_screen.dart'; 
+import './saved_addresses_screen.dart'; // <<< NEW IMPORT
 
 class EditProfileScreen extends StatefulWidget {
   final Map<String, dynamic> userData;
@@ -71,19 +72,38 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       MaterialPageRoute(builder: (context) => const AboutScreen()), 
     );
   }
+
+  void _navigateToSavedAddressesScreen() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => const SavedAddressesScreen()), // <<< MODIFIED
+    );
+  }
   
   void _handleLogout() {
-    // Navigate to WelcomeScreen and remove all routes behind it.
     Navigator.of(context).pushAndRemoveUntil(
       MaterialPageRoute(builder: (context) => const WelcomeScreen()), 
-      (Route<dynamic> route) => false, // This predicate ensures all previous routes are removed.
+      (Route<dynamic> route) => false, 
     );
   }
 
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16.0, 20.0, 16.0, 8.0),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          fontWeight: FontWeight.bold,
+          color: Theme.of(context).colorScheme.primary,
+        ),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     final themeProvider = Provider.of<ThemeProvider>(context);
+    final theme = Theme.of(context); 
 
     return Scaffold(
       appBar: AppBar(
@@ -101,10 +121,9 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       ),
       body: ListView(
         children: <Widget>[
-          // User Info Header
           Container(
             padding: const EdgeInsets.all(20.0),
-            color: Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3),
+            color: theme.colorScheme.primaryContainer.withOpacity(0.3),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
@@ -116,12 +135,12 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 const SizedBox(height: 12),
                 Text(
                   _displayName,
-                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+                  style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 4),
                 Text(
                   _displayEmail,
-                  style: Theme.of(context).textTheme.bodyMedium,
+                  style: theme.textTheme.bodyMedium,
                 ),
               ],
             ),
@@ -143,6 +162,12 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                 const SnackBar(content: Text('Change Password screen would open here.')),
               );
             },
+          ),
+          ListTile( 
+            leading: const Icon(Icons.location_on_outlined), 
+            title: const Text('Saved Addresses'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: _navigateToSavedAddressesScreen, 
           ),
 
           _buildSectionTitle(context, "App Settings"),
@@ -188,25 +213,12 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
           const Divider(height: 32, thickness: 1),
 
           ListTile(
-            leading: Icon(Icons.logout, color: Theme.of(context).colorScheme.error),
-            title: Text('Logout', style: TextStyle(color: Theme.of(context).colorScheme.error)),
+            leading: Icon(Icons.logout, color: theme.colorScheme.error),
+            title: Text('Logout', style: TextStyle(color: theme.colorScheme.error)),
             onTap: _handleLogout,
           ),
           const SizedBox(height: 20),
         ],
-      ),
-    );
-  }
-
-  Widget _buildSectionTitle(BuildContext context, String title) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16.0, 20.0, 16.0, 8.0),
-      child: Text(
-        title,
-        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-          fontWeight: FontWeight.bold,
-          color: Theme.of(context).colorScheme.primary,
-        ),
       ),
     );
   }

--- a/lib/screens/map_selection_screen.dart
+++ b/lib/screens/map_selection_screen.dart
@@ -1,65 +1,80 @@
 import 'dart:async';
+import 'dart:convert'; // For jsonEncode/Decode
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:geolocator/geolocator.dart';
-import 'package:geocoding/geocoding.dart'; 
+import 'package:geocoding/geocoding.dart';
+import 'package:http/http.dart' as http; // For HTTP requests
 
 class MapSelectionScreen extends StatefulWidget {
-  const MapSelectionScreen({Key? key}) : super(key: key);
+  final String addressType;
+  final int userId;
+
+  const MapSelectionScreen({
+    Key? key,
+    required this.addressType,
+    required this.userId,
+  }) : super(key: key);
 
   @override
-  _MapSelectionScreenState createState() => _MapSelectionScreenState();
+  _MapSelectionScreenState createState() => _MapSelectionScreenState(); // Ensure this matches
 }
 
 class _MapSelectionScreenState extends State<MapSelectionScreen> {
   final Completer<GoogleMapController> _mapController = Completer();
-  LatLng _lastMapPosition = const LatLng(0, 0);
+  LatLng _lastMapPosition = const LatLng(20.5937, 78.9629); // Default to a general view (e.g., India)
   final TextEditingController _searchController = TextEditingController();
 
   bool _locationFeaturesEnabled = false;
   bool _isMapCenteredOnUser = false;
   bool _isProgrammaticMove = false;
+  bool _isSaving = false; // To handle loading state during API call
 
   static final CameraPosition _kInitialNeutralView = CameraPosition(
-    target: const LatLng(0, 0),
-    zoom: 2.0,
+    target: const LatLng(20.5937, 78.9629), // Default initial view (e.g., India)
+    zoom: 3.0,
   );
 
   @override
   void initState() {
     super.initState();
+    _animateToInitialCountryView(); // Attempt to get user location or use default
   }
 
   Future<void> _animateToInitialCountryView() async {
-    if (mounted) {
-      try {
-        final PermissionStatus permission = await Permission.locationWhenInUse.request();
-        if (permission == PermissionStatus.granted) {
-          bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
-          if (serviceEnabled) {
-            final Position position = await Geolocator.getCurrentPosition(
-              desiredAccuracy: LocationAccuracy.low,
-            );
-            final GoogleMapController controller = await _mapController.future;
-            if (mounted) {
-              setState(() {
-                _isProgrammaticMove = true;
-                _isMapCenteredOnUser = true; 
-                _lastMapPosition = LatLng(position.latitude, position.longitude);
-              });
-              controller.animateCamera(CameraUpdate.newCameraPosition(
-                CameraPosition(
-                  target: LatLng(position.latitude, position.longitude),
-                  zoom: 6.0, 
-                ),
-              ));
-            }
+    if (!mounted) return;
+    try {
+      final PermissionStatus permission = await Permission.locationWhenInUse.request();
+      if (permission == PermissionStatus.granted) {
+        bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+        if (serviceEnabled) {
+          final Position position = await Geolocator.getCurrentPosition(
+            desiredAccuracy: LocationAccuracy.low,
+          );
+          _lastMapPosition = LatLng(position.latitude, position.longitude);
+          final GoogleMapController controller = await _mapController.future;
+          if (mounted) {
+            controller.animateCamera(CameraUpdate.newCameraPosition(
+              CameraPosition(target: _lastMapPosition, zoom: 6.0),
+            ));
+            setState(() {
+              _isProgrammaticMove = true;
+              _isMapCenteredOnUser = true;
+            });
           }
+          return; // Exit if successful
         }
-      } catch (e) {
-        print('Error animating to initial country view: $e');
       }
+    } catch (e) {
+      print('Error animating to initial country view: $e');
+    }
+    // Fallback if permission/service denied or error
+    if (mounted && _mapController.isCompleted) {
+        final GoogleMapController controller = await _mapController.future;
+        controller.animateCamera(CameraUpdate.newCameraPosition(_kInitialNeutralView));
+    } else if (mounted) {
+        // If controller not ready, _lastMapPosition is already at default
     }
   }
 
@@ -69,166 +84,166 @@ class _MapSelectionScreenState extends State<MapSelectionScreen> {
     super.dispose();
   }
 
-  Future<void> _goToCurrentUserLocation() async { 
-    if (!_locationFeaturesEnabled && mounted) {
-        setState(() {
-            _locationFeaturesEnabled = true;
-        });
-        await Future.delayed(const Duration(milliseconds: 100)); 
+  Future<void> _goToCurrentUserLocation() async {
+    if (!mounted) return;
+    if (!_locationFeaturesEnabled) {
+      setState(() {
+        _locationFeaturesEnabled = true;
+      });
+      await Future.delayed(const Duration(milliseconds: 100));
     }
 
     final PermissionStatus permission = await Permission.locationWhenInUse.request();
-
     if (permission == PermissionStatus.granted) {
       try {
         bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
         if (!serviceEnabled) {
-          if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Location services are disabled.')),
-            );
-          }
+          if (mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Location services are disabled.')));
           return;
         }
-
-        final Position position = await Geolocator.getCurrentPosition(
-          desiredAccuracy: LocationAccuracy.high, 
-        );
+        final Position position = await Geolocator.getCurrentPosition(desiredAccuracy: LocationAccuracy.high);
         final GoogleMapController controller = await _mapController.future;
-
         if (mounted) {
+          _lastMapPosition = LatLng(position.latitude, position.longitude);
+          controller.animateCamera(CameraUpdate.newCameraPosition(
+            CameraPosition(target: _lastMapPosition, zoom: 16.0),
+          ));
           setState(() {
             _isProgrammaticMove = true;
             _isMapCenteredOnUser = true;
-            _lastMapPosition = LatLng(position.latitude, position.longitude);
           });
         }
-        
-        controller.animateCamera(CameraUpdate.newCameraPosition(
-          CameraPosition(
-            target: LatLng(position.latitude, position.longitude),
-            zoom: 16.0, 
-          ),
-        ));
-
       } catch (e) {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Error getting location: ${e.toString()}')),
-          );
-          if (mounted && _isMapCenteredOnUser) {
-            setState((){
-              _isMapCenteredOnUser = false;
-            });
-          }
-        }
+        if (mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Error getting location: ${e.toString()}')));
       }
     } else {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(permission == PermissionStatus.denied 
-              ? 'Location permission denied.'
-              : 'Location permission permanently denied. Please enable it in app settings.')),
-        );
-        if (mounted && _isMapCenteredOnUser) {
-          setState((){
-            _isMapCenteredOnUser = false;
-          });
-        }
-      }
+      if (mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(permission == PermissionStatus.denied ? 'Location permission denied.' : 'Location permission permanently denied.')));
     }
   }
 
   void _onMapCreated(GoogleMapController controller) {
-    if (!_mapController.isCompleted) {
-      _mapController.complete(controller);
+    if (!_mapController.isCompleted) _mapController.complete(controller);
+    // _animateToInitialCountryView is called from initState, which might run before or after this based on widget tree build.
+    // If map is created and initial animation hasn't set a good position, re-trigger or ensure it happens.
+    if (_lastMapPosition.latitude == _kInitialNeutralView.target.latitude && _lastMapPosition.longitude == _kInitialNeutralView.target.longitude) {
+        _animateToInitialCountryView(); // Re-attempt if still at broad default
     }
-    _animateToInitialCountryView();
-    Future.delayed(const Duration(milliseconds: 500), () {
-      if (mounted) {
-        setState(() {
-          _locationFeaturesEnabled = true;
-        });
-      }
-    });
+    if (mounted) setState(() => _locationFeaturesEnabled = true);
   }
 
   void _onCameraMove(CameraPosition position) {
     if (mounted) {
       _lastMapPosition = position.target;
       if (!_isProgrammaticMove && _isMapCenteredOnUser) {
-        setState(() {
-          _isMapCenteredOnUser = false;
-        });
+        setState(() => _isMapCenteredOnUser = false);
       }
     }
   }
 
   void _onCameraIdle() {
     if (mounted && _isProgrammaticMove) {
-      setState(() {
-        _isProgrammaticMove = false;
-      });
+      setState(() => _isProgrammaticMove = false);
+    }
+  }
+
+  Future<void> _sendAddressToApi(Placemark place, LatLng coordinates) async {
+    if (!mounted) return;
+    setState(() => _isSaving = true);
+
+    String addressLine1 = place.street ?? place.name ?? '';
+    String addressLine2 = place.subLocality ?? (place.thoroughfare != place.street ? place.thoroughfare : '') ?? '';
+    if (addressLine1.isEmpty) addressLine1 = place.locality ?? 'N/A';
+
+    String mapAddress = [
+      place.name,
+      place.street,
+      place.subLocality,
+      place.locality,
+      place.administrativeArea,
+      place.postalCode,
+      place.country
+    ].where((s) => s != null && s.isNotEmpty).toSet().join(', ');
+    if (mapAddress.isEmpty) mapAddress = "Selected Location at ${coordinates.latitude.toStringAsFixed(5)}, ${coordinates.longitude.toStringAsFixed(5)}";
+    
+    const String apiUrl = 'http://192.168.1.100/washio_api/add_address.php'; // !!! REPLACE WITH YOUR ACTUAL IP/DOMAIN !!!
+
+    try {
+      final response = await http.post(
+        Uri.parse(apiUrl),
+        body: {
+          'user_id': widget.userId.toString(),
+          'address_type': widget.addressType,
+          'address_line1': addressLine1,
+          'address_line2': addressLine2,
+          'longitude': coordinates.longitude.toString(),
+          'latitude': coordinates.latitude.toString(),
+          'map_address': mapAddress,
+        },
+      ).timeout(const Duration(seconds: 10));
+
+      if (!mounted) return;
+      final responseData = jsonDecode(response.body);
+      if (response.statusCode == 200 && responseData['status'] == 'success') {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(responseData['message'] ?? 'Address saved!'), backgroundColor: Colors.green));
+        Navigator.pop(context, true); // Pop with success
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(responseData['message'] ?? 'Failed to save address. Server error.'), backgroundColor: Colors.red));
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Error: ${e.toString()}'), backgroundColor: Colors.red));
+    } finally {
+      if (mounted) setState(() => _isSaving = false);
     }
   }
 
   Future<void> _selectLocation() async {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Fetching address...'), duration: Duration(seconds: 1)),
-    );
+    if (_isSaving || !mounted) return;
+
+    // Get current map center if _lastMapPosition is still default (or seems uninitialized)
+    // This ensures we use the pin's location if the map hasn't moved much
+    if (_mapController.isCompleted ) {
+         final GoogleMapController controller = await _mapController.future;
+         // Get center of the map view
+         LatLngBounds visibleRegion = await controller.getVisibleRegion();
+        _lastMapPosition = LatLng(
+            (visibleRegion.northeast.latitude + visibleRegion.southwest.latitude) / 2,
+            (visibleRegion.northeast.longitude + visibleRegion.southwest.longitude) / 2,
+        );
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Fetching address details...'), duration: Duration(seconds: 2)));
 
     try {
-      List<Placemark> placemarks = await placemarkFromCoordinates(
-        _lastMapPosition.latitude,
-        _lastMapPosition.longitude,
-      );
-
+      List<Placemark> placemarks = await placemarkFromCoordinates(_lastMapPosition.latitude, _lastMapPosition.longitude);
+      if (!mounted) return;
       if (placemarks.isNotEmpty) {
-        Placemark place = placemarks.first;
-        String formattedAddress = "";
-        if (place.street != null && place.street!.isNotEmpty) formattedAddress += "${place.street}, ";
-        if (place.subLocality != null && place.subLocality!.isNotEmpty) formattedAddress += "${place.subLocality}, ";
-        if (place.locality != null && place.locality!.isNotEmpty) formattedAddress += "${place.locality}, ";
-        if (place.postalCode != null && place.postalCode!.isNotEmpty) formattedAddress += "${place.postalCode}, ";
-        if (place.country != null && place.country!.isNotEmpty) formattedAddress += "${place.country}";
-        
-        if (formattedAddress.endsWith(", ")) {
-            formattedAddress = formattedAddress.substring(0, formattedAddress.length - 2);
-        }
-
-        if (mounted) Navigator.pop(context, formattedAddress);
+        await _sendAddressToApi(placemarks.first, _lastMapPosition);
       } else {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Could not find address for this location.')),
-          );
-          Navigator.pop(context, null); 
-        }
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Could not find address for this location.')));
       }
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error fetching address: ${e.toString()}')),
-        );
-        Navigator.pop(context, null); 
-      }
+      if (mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Error fetching address details: ${e.toString()}')));
     }
   }
 
   Future<void> _searchAndGoToLocation() async {
     final String query = _searchController.text;
-    if (query.isEmpty) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Please enter a location to search.')),
-        );
+    if (query.isEmpty || !mounted) return;
+    try {
+      List<Location> locations = await locationFromAddress(query);
+      if (!mounted) return;
+      if (locations.isNotEmpty) {
+        final GoogleMapController controller = await _mapController.future;
+        final targetLocation = LatLng(locations.first.latitude, locations.first.longitude);
+        _lastMapPosition = targetLocation; // Update last position after search
+        controller.animateCamera(CameraUpdate.newCameraPosition(CameraPosition(target: targetLocation, zoom: 15.0)));
+        setState(() => _isMapCenteredOnUser = false ); // Searched location might not be user's current
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Location "$query" not found.')));
       }
-      return;
-    }
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Search for "$query" not implemented yet.')),
-      );
+    } catch (e) {
+      if (mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Error searching location: ${e.toString()}')));
     }
   }
 
@@ -236,40 +251,29 @@ class _MapSelectionScreenState extends State<MapSelectionScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Select Location'), // Title restored
+        title: Text('Select ${widget.addressType} Address'),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.check),
-            tooltip: 'Select this location',
-            onPressed: _selectLocation,
-          )
+          if (_isSaving)
+            const Padding(padding: EdgeInsets.all(16.0), child: SizedBox(height: 20, width: 20, child: CircularProgressIndicator(color: Colors.white, strokeWidth: 3)))
+          else
+            IconButton(icon: const Icon(Icons.check), tooltip: 'Confirm this location', onPressed: _selectLocation)
         ],
       ),
       body: Stack(
         children: <Widget>[
           GoogleMap(
             mapType: MapType.normal,
-            initialCameraPosition: _kInitialNeutralView, 
+            initialCameraPosition: _kInitialNeutralView,
             onMapCreated: _onMapCreated,
             onCameraMove: _onCameraMove,
             onCameraIdle: _onCameraIdle,
             myLocationEnabled: _locationFeaturesEnabled,
-            myLocationButtonEnabled: _locationFeaturesEnabled,
+            myLocationButtonEnabled: false, // Using custom FAB for this
             zoomControlsEnabled: true,
           ),
-          const Center(
-            child: IgnorePointer(
-              child: Icon(
-                Icons.location_pin,
-                color: Colors.red,
-                size: 40.0,
-              ),
-            ),
-          ),
+          const Center(child: IgnorePointer(child: Icon(Icons.location_pin, color: Colors.red, size: 40.0))),
           Positioned(
-            top: 10.0,
-            left: 10.0,
-            right: 10.0,
+            top: 10.0, left: 10.0, right: 10.0,
             child: Card(
               elevation: 4.0,
               child: Padding(
@@ -279,18 +283,11 @@ class _MapSelectionScreenState extends State<MapSelectionScreen> {
                     Expanded(
                       child: TextField(
                         controller: _searchController,
-                        decoration: const InputDecoration(
-                          hintText: 'Search for a location...',
-                          border: InputBorder.none,
-                        ),
-                        onSubmitted: (value) => _searchAndGoToLocation(),
+                        decoration: const InputDecoration(hintText: 'Search location...', border: InputBorder.none),
+                        onSubmitted: (_) => _searchAndGoToLocation(),
                       ),
                     ),
-                    IconButton(
-                      icon: const Icon(Icons.search),
-                      onPressed: _searchAndGoToLocation,
-                      tooltip: 'Search Location',
-                    ),
+                    IconButton(icon: const Icon(Icons.search), onPressed: _searchAndGoToLocation, tooltip: 'Search Location'),
                   ],
                 ),
               ),
@@ -298,34 +295,28 @@ class _MapSelectionScreenState extends State<MapSelectionScreen> {
           ),
           if (_locationFeaturesEnabled)
             Positioned(
-              bottom: 95.0,
-              right: 10.0,
+              bottom: MediaQuery.of(context).padding.bottom + 80 + 15, // Above main FAB
+              right: 15.0,
               child: FloatingActionButton(
                 mini: true,
-                backgroundColor: Colors.blue,
+                heroTag: 'myLocationButton',
+                backgroundColor: Theme.of(context).colorScheme.secondary,
                 tooltip: _isMapCenteredOnUser ? 'Location centered' : 'My Location',
-                onPressed: _goToCurrentUserLocation, 
-                child: AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 300),
-                  transitionBuilder: (Widget child, Animation<double> animation) {
-                    return FadeTransition(opacity: animation, child: child);
-                  },
-                  child: Icon(
-                    _isMapCenteredOnUser ? Icons.gps_fixed : Icons.my_location,
-                    key: ValueKey<bool>(_isMapCenteredOnUser),
-                    color: _isMapCenteredOnUser ? Colors.white : Colors.red,
-                  ),
-                ),
+                onPressed: _goToCurrentUserLocation,
+                child: Icon(_isMapCenteredOnUser ? Icons.gps_fixed : Icons.my_location, color: Colors.white ),
               ),
             ),
         ],
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
       floatingActionButton: FloatingActionButton.extended(
-        onPressed: _selectLocation,
-        label: const Text('Select Current Center', style: TextStyle(color: Colors.white)),
-        icon: const Icon(Icons.location_on, color: Colors.white),
-        backgroundColor: Colors.blue,
+        heroTag: 'selectLocationButton',
+        onPressed: _isSaving ? null : _selectLocation,
+        label: Text(_isSaving ? 'SAVING...' : 'Confirm ${widget.addressType} Location', style: const TextStyle(color: Colors.white)),
+        icon: _isSaving 
+            ? Container(width: 24, height: 24, padding: const EdgeInsets.all(2.0), child: const CircularProgressIndicator(color: Colors.white, strokeWidth: 3))
+            : const Icon(Icons.check_circle_outline, color: Colors.white),
+        backgroundColor: _isSaving ? Colors.grey : Theme.of(context).colorScheme.primary,
       ),
     );
   }

--- a/lib/screens/saved_addresses_screen.dart
+++ b/lib/screens/saved_addresses_screen.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import './map_selection_screen.dart'; // Ensure this path is correct
+
+class SavedAddressesScreen extends StatelessWidget {
+  const SavedAddressesScreen({Key? key}) : super(key: key);
+
+  void _navigateToMapSelection(BuildContext context, String addressType) {
+    // TODO: Replace '1' with the actual logged-in user ID from your auth system/state management
+    int currentUserId = 1; 
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => MapSelectionScreen(
+          addressType: addressType,
+          userId: currentUserId,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Saved Addresses'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(0), 
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16.0, 16.0, 8.0, 8.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Your Addresses', 
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                IconButton(
+                  icon: Icon(Icons.add_circle_outline, color: theme.colorScheme.primary),
+                  tooltip: 'Add New Address',
+                  iconSize: 28,
+                  onPressed: () {
+                    _navigateToMapSelection(context, 'Other'); // 'Other' or 'Generic' for the general add button
+                  },
+                ),
+              ],
+            ),
+          ),
+          const Divider(),
+
+          ListTile(
+            leading: Icon(Icons.home_outlined, color: theme.colorScheme.secondary, size: 28),
+            title: const Text('Add Home'),
+            subtitle: const Text('Save your home address for faster checkout'),
+            trailing: Icon(Icons.add_circle_outline, color: Colors.green[600], size: 26),
+            onTap: () {
+              _navigateToMapSelection(context, 'Home');
+            },
+          ),
+          const Divider(indent: 16, endIndent: 16),
+
+          ListTile(
+            leading: Icon(Icons.work_outline, color: theme.colorScheme.secondary, size: 28),
+            title: const Text('Add Work'),
+            subtitle: const Text('Save your work address for convenience'),
+            trailing: Icon(Icons.add_circle_outline, color: Colors.green[600], size: 26),
+            onTap: () {
+              _navigateToMapSelection(context, 'Work');
+            },
+          ),
+          const Divider(),
+        ],
+      ),
+    );
+  }
+}

--- a/washio_api/htdocs/add_address.php
+++ b/washio_api/htdocs/add_address.php
@@ -1,0 +1,58 @@
+<?php
+header('Content-Type: application/json');
+include 'db.php'; // Your database connection file
+
+// Get the posted data
+// It's good practice to ensure these are set and sanitize them
+$user_id = isset($_POST['user_id']) ? mysqli_real_escape_string($conn, $_POST['user_id']) : null;
+$address_type = isset($_POST['address_type']) ? mysqli_real_escape_string($conn, $_POST['address_type']) : null; // e.g., 'Home', 'Work', 'Other'
+$address_line1 = isset($_POST['address_line1']) ? mysqli_real_escape_string($conn, $_POST['address_line1']) : null;
+$address_line2 = isset($_POST['address_line2']) ? mysqli_real_escape_string($conn, $_POST['address_line2']) : null; // Optional
+$longitude = isset($_POST['longitude']) ? mysqli_real_escape_string($conn, $_POST['longitude']) : null;
+$latitude = isset($_POST['latitude']) ? mysqli_real_escape_string($conn, $_POST['latitude']) : null;
+$map_address = isset($_POST['map_address']) ? mysqli_real_escape_string($conn, $_POST['map_address']) : null; // Full address string from map selection
+
+$response = array();
+
+// Corrected table name
+$tableName = 'user_locations'; 
+
+if ($user_id && $address_type && $address_line1 && $longitude && $latitude && $map_address) {
+    // Address_line2 can be NULL, so we handle it differently if not provided
+    if ($address_line2 === null || $address_line2 === '') {
+        $sql = "INSERT INTO $tableName (userTB, Address_Type, Address_Line1, longitude, latitude, Map_Address, created_at, updated_at) 
+                VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())";
+        $stmt = mysqli_prepare($conn, $sql);
+        mysqli_stmt_bind_param($stmt, 'isssss', $user_id, $address_type, $address_line1, $longitude, $latitude, $map_address);
+    } else {
+        $sql = "INSERT INTO $tableName (userTB, Address_Type, Address_Line1, Address_Line2, longitude, latitude, Map_Address, created_at, updated_at) 
+                VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW())";
+        $stmt = mysqli_prepare($conn, $sql);
+        mysqli_stmt_bind_param($stmt, 'issssss', $user_id, $address_type, $address_line1, $address_line2, $longitude, $latitude, $map_address);
+    }
+
+    if (mysqli_stmt_execute($stmt)) {
+        $response['status'] = 'success';
+        $response['message'] = 'Address added successfully.';
+        $response['address_id'] = mysqli_insert_id($conn); // Get the ID of the newly inserted address
+    } else {
+        $response['status'] = 'error';
+        $response['message'] = 'Failed to add address: ' . mysqli_stmt_error($stmt);
+    }
+    mysqli_stmt_close($stmt);
+} else {
+    $response['status'] = 'error';
+    $response['message'] = 'Required fields are missing.';
+    $missing_fields = [];
+    if (!$user_id) $missing_fields[] = 'user_id';
+    if (!$address_type) $missing_fields[] = 'address_type';
+    if (!$address_line1) $missing_fields[] = 'address_line1';
+    if (!$longitude) $missing_fields[] = 'longitude';
+    if (!$latitude) $missing_fields[] = 'latitude';
+    if (!$map_address) $missing_fields[] = 'map_address';
+    $response['missing_fields'] = $missing_fields;
+}
+
+mysqli_close($conn);
+echo json_encode($response);
+?>


### PR DESCRIPTION
Introduces a SavedAddressesScreen for managing user addresses and integrates address saving via a new add_address.php API endpoint. Dashboard and map selection screens are refactored to support address types and user IDs, enabling users to add and save locations (Home, Work, Other) to the backend.