### PR TITLE
Implement cart checkout and order creation API

### DIFF
--- a/lib/cart_provider.dart
+++ b/lib/cart_provider.dart
@@ -2,34 +2,74 @@
 import 'package:flutter/foundation.dart';
 
 class CartProvider with ChangeNotifier {
-  final List<Map<String, dynamic>> _items = [];
+  // Use a Map to store items, with the service ID as the key.
+  // The value will be a map containing the service details and its quantity.
+  final Map<int, Map<String, dynamic>> _items = {};
 
-  List<Map<String, dynamic>> get items => [..._items];
+  // Getter to return all cart items as a list.
+  List<Map<String, dynamic>> get items => _items.values.toList();
 
-  int get itemCount => _items.length;
+  // Getter for the total number of items (sum of all quantities).
+  int get itemCount {
+    return _items.values.fold(0, (sum, item) => sum + (item['quantity'] as int));
+  }
 
+  // Getter for the total price, considering quantities.
   double get totalPrice {
-    var total = 0.0;
-    for (var item in _items) {
-      // Assumes 'service_price' is the key and its value is a number.
-      total += (item['service_price'] as num?) ?? 0.0;
-    }
-    return total;
+    return _items.values.fold(0.0, (sum, item) {
+      final price = (item['service_price'] as num?) ?? 0.0;
+      final quantity = (item['quantity'] as int?) ?? 0;
+      return sum + (price * quantity);
+    });
   }
 
-  // Adds a service to the cart.
+  // Adds a service to the cart or increments its quantity.
   void addItem(Map<String, dynamic> service) {
-    // For now, we allow duplicate services. A more advanced cart might
-    // check for existence and increase a quantity counter.
-    _items.add(service);
-    notifyListeners(); // This tells widgets listening to this provider to rebuild.
+    final int serviceId = service['id'] as int;
+
+    if (_items.containsKey(serviceId)) {
+      // If item already exists, just increase the quantity.
+      _items.update(serviceId, (existingItem) {
+        existingItem['quantity'] = (existingItem['quantity'] as int) + 1;
+        return existingItem;
+      });
+    } else {
+      // If it's a new item, add it to the cart with a quantity of 1.
+      _items[serviceId] = {
+        ...service,
+        'quantity': 1,
+      };
+    }
+    notifyListeners();
   }
 
-  // Removes a service from the cart.
-  // Assumes the service map contains a unique 'id'.
+  // Decrements an item's quantity or removes it if quantity is 1.
+  // This is useful for an "undo" action.
   void removeItem(Map<String, dynamic> service) {
-    _items.removeWhere((item) => item['id'] == service['id']);
+    final int serviceId = service['id'] as int;
+
+    if (!_items.containsKey(serviceId)) {
+      return; // Item not in cart
+    }
+
+    if ((_items[serviceId]?['quantity'] as int) > 1) {
+      _items.update(serviceId, (existingItem) {
+        existingItem['quantity'] = (existingItem['quantity'] as int) - 1;
+        return existingItem;
+      });
+    } else {
+      // If quantity is 1, remove the item completely.
+      _items.remove(serviceId);
+    }
     notifyListeners();
+  }
+
+  // Completely removes an item from the cart, regardless of quantity.
+  void removeFullItem(int serviceId) {
+    if (_items.containsKey(serviceId)) {
+      _items.remove(serviceId);
+      notifyListeners();
+    }
   }
 
   // Clears all items from the cart.
@@ -40,6 +80,7 @@ class CartProvider with ChangeNotifier {
 
   // Check if a specific service is already in the cart.
   bool isInCart(Map<String, dynamic> service) {
-    return _items.any((item) => item['id'] == service['id']);
+    final int serviceId = service['id'] as int;
+    return _items.containsKey(serviceId);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:provider/provider.dart';
 import 'theme_provider.dart';
 import 'cart_provider.dart';
 import 'screens/welcome_screen.dart';
-import 'screens/cart_screen.dart'; // <<< IMPORT CART SCREEN
+import 'screens/cart_screen.dart'; 
 
 void main() async { 
   WidgetsFlutterBinding.ensureInitialized(); 
@@ -98,7 +98,10 @@ class MyApp extends StatelessWidget {
       initialRoute: '/',
       routes: {
         '/': (context) => const WelcomeScreen(),
-        '/cart': (context) => const CartScreen(), // <<< ADDED CART ROUTE
+        '/cart': (context) {
+          final userId = ModalRoute.of(context)!.settings.arguments as int;
+          return CartScreen(userId: userId);
+        },
         '/verification': (context) {
           final Object? args = ModalRoute.of(context)!.settings.arguments;
           final String phoneNumber = (args is String) ? args : ""; 

--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -1,9 +1,79 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
 import '../cart_provider.dart';
+import '../api.dart'; // For API base URL
 
-class CartScreen extends StatelessWidget {
-  const CartScreen({Key? key}) : super(key: key);
+class CartScreen extends StatefulWidget {
+  final int userId;
+
+  const CartScreen({Key? key, required this.userId}) : super(key: key);
+
+  @override
+  _CartScreenState createState() => _CartScreenState();
+}
+
+class _CartScreenState extends State<CartScreen> {
+  bool _isProcessing = false;
+
+  Future<void> _handleCheckout(CartProvider cart) async {
+    if (cart.items.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Your cart is empty.')),
+      );
+      return;
+    }
+
+    setState(() {
+      _isProcessing = true;
+    });
+
+    final firstItem = cart.items.first;
+    final stationId = firstItem['station_id'] as int? ?? 0; // Ensure station_id exists in your service item map
+
+    final url = Uri.parse('${ApiService.baseUrl}/create_order.php');
+
+    try {
+      final response = await http.post(
+        url,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({
+          'user_id': widget.userId,
+          'station_id': stationId,
+          'items': cart.items,
+          'total_amount': cart.totalPrice,
+          'payment_method': 'cash_on_delivery', // Or get from UI
+        }),
+      );
+
+      if (!mounted) return;
+
+      final responseData = jsonDecode(response.body);
+
+      if (responseData['status'] == 'success') {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(responseData['message']), backgroundColor: Colors.green),
+        );
+        cart.clearCart();
+        Navigator.of(context).pop();
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(responseData['message']), backgroundColor: Colors.red),
+        );
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('An error occurred: ${e.toString()}'), backgroundColor: Colors.red),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isProcessing = false;
+        });
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,15 +100,15 @@ class CartScreen extends StatelessWidget {
                       final item = cart.items[index];
                       final itemName = item['service_name']?.toString() ?? 'Service';
                       final itemPrice = (item['service_price'] as num?)?.toStringAsFixed(2) ?? '0.00';
+                      final quantity = item['quantity'] as int? ?? 1;
 
                       return ListTile(
                         title: Text(itemName),
-                        subtitle: Text('\$$itemPrice'),
+                        subtitle: Text('\$$itemPrice x $quantity'),
                         trailing: IconButton(
                           icon: const Icon(Icons.remove_circle_outline, color: Colors.red),
                           onPressed: () {
-                            // This will remove the item from the cart
-                            cart.removeItem(item);
+                            cart.removeFullItem(item['id'] as int);
                           },
                         ),
                       );
@@ -72,13 +142,10 @@ class CartScreen extends StatelessWidget {
                 minimumSize: const Size(double.infinity, 50),
                 shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
               ),
-              onPressed: cart.items.isEmpty ? null : () {
-                // TODO: Implement checkout logic
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Checkout process not implemented yet.')),
-                );
-              },
-              child: const Text('Proceed to Checkout', style: TextStyle(fontSize: 16)),
+              onPressed: (cart.items.isEmpty || _isProcessing) ? null : () => _handleCheckout(cart),
+              child: _isProcessing
+                  ? const CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white))
+                  : const Text('Proceed to Checkout', style: TextStyle(fontSize: 16)),
             ),
           ),
         ],

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -103,18 +103,17 @@ class _AppShellState extends State<AppShell> {
       ),
       floatingActionButton: Consumer<CartProvider>(
         builder: (context, cart, child) {
-          // Only show the button if there are items in the cart
           return cart.itemCount > 0
               ? Badge(
                   label: Text(cart.itemCount.toString()),
                   child: FloatingActionButton(
                     onPressed: () {
-                      Navigator.pushNamed(context, '/cart');
+                      Navigator.pushNamed(context, '/cart', arguments: widget.userData['id'] as int);
                     },
                     child: const Icon(Icons.shopping_cart),
                   ),
                 )
-              : const SizedBox.shrink(); // Return an empty widget if cart is empty
+              : const SizedBox.shrink(); 
         },
       ),
     );

--- a/lib/screens/services_screen.dart
+++ b/lib/screens/services_screen.dart
@@ -202,14 +202,19 @@ class _ServicesScreenState extends State<ServicesScreen> {
                   child: InkWell(
                     onTap: () {
                       final cart = Provider.of<CartProvider>(context, listen: false);
-                      cart.addItem(service);
+                      // Create a new map with the service data and the station ID
+                      final itemToAdd = {
+                        ...service,
+                        'station_id': _selectedStation!['id'],
+                      };
+                      cart.addItem(itemToAdd);
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
                           content: Text('$serviceName added to cart'),
                           duration: const Duration(seconds: 2),
                           action: SnackBarAction(
                             label: 'UNDO',
-                            onPressed: () => cart.removeItem(service),
+                            onPressed: () => cart.removeItem(itemToAdd),
                           ),
                         ),
                       );
@@ -310,7 +315,6 @@ class _ServicesScreenState extends State<ServicesScreen> {
         ],
       ),
       body: isViewingStationDetails ? _buildSelectedStationServices() : _buildStationsList(),
-      // FLOATING ACTION BUTTON REMOVED FROM HERE
     );
   }
 }

--- a/washio_api/htdocs/create_order.php
+++ b/washio_api/htdocs/create_order.php
@@ -1,0 +1,120 @@
+<?php
+// Start output buffering and set error reporting
+ob_start();
+error_reporting(E_ALL);
+ini_set('display_errors', 0); 
+ini_set('log_errors', 1);
+
+// Set headers for JSON response
+if (!headers_sent()) {
+    header("Content-Type: application/json");
+}
+
+// Include the database connection
+require __DIR__ . '/db.php';
+
+// Basic check for DB connection
+if (!isset($conn) || $conn->connect_error) {
+    if (ob_get_level() > 0) ob_end_clean();
+    if (!headers_sent()) header("Content-Type: application/json");
+    echo json_encode(['status' => 'error', 'message' => 'Database connection failed.']);
+    exit;
+}
+
+// --- Main Logic ---
+
+// Get the raw POST data from the request body
+$json_data = file_get_contents('php://input');
+
+// Decode the JSON data into a PHP associative array
+$data = json_decode($json_data, true);
+
+// Validate the incoming data structure
+if (!isset($data['user_id'], $data['station_id'], $data['items'], $data['total_amount'], $data['payment_method']) || !is_array($data['items'])) {
+    if (ob_get_level() > 0) ob_end_clean();
+    if (!headers_sent()) header("Content-Type: application/json");
+    echo json_encode(['status' => 'error', 'message' => 'Invalid data provided. Required: user_id, station_id, items, total_amount, payment_method.']);
+    exit;
+}
+
+// Assign variables from the decoded data
+$user_id = $data['user_id'];
+$station_id = $data['station_id'];
+$items = $data['items'];
+$total_amount = $data['total_amount'];
+$payment_method = $data['payment_method'];
+
+// Start a database transaction
+$conn->begin_transaction();
+
+try {
+    // Step 1: Insert the main order into `oder_tb`
+    // Note: service_Tb in `oder_tb` seems redundant if it's a multi-item order. 
+    // Here we will insert the ID of the first service as a reference, as the column is NOT NULL.
+    // A better schema might allow this to be NULL.
+    $first_service_id = $items[0]['id']; // Get ID of the first item for the main order table
+    
+    $stmt_order = $conn->prepare(
+        "INSERT INTO oder_tb (user_Tb, station_Tb, service_Tb, amount, payment_method, status, payment_status) VALUES (?, ?, ?, ?, ?, 'pending', 'unpaid')"
+    );
+    if (!$stmt_order) {
+        throw new Exception("Order statement preparation failed: " . $conn->error);
+    }
+    $stmt_order->bind_param("iiids", $user_id, $station_id, $first_service_id, $total_amount, $payment_method);
+    
+    if (!$stmt_order->execute()) {
+        throw new Exception("Failed to create order: " . $stmt_order->error);
+    }
+    
+    $order_id = $stmt_order->insert_id;
+    $stmt_order->close();
+
+    // Step 2: Insert each item from the cart into `oder_items`
+    $stmt_items = $conn->prepare(
+        "INSERT INTO oder_items (oderTb, userTb, stationTb, serviceTb, item, price, item_quantity) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    );
+    if (!$stmt_items) {
+        throw new Exception("Order items statement preparation failed: " . $conn->error);
+    }
+
+    foreach ($items as $item) {
+        $service_id = $item['id'];
+        $service_name = $item['service_name'];
+        $service_price = $item['service_price'];
+        $quantity = $item['quantity'];
+
+        // Bind parameters and execute for each item
+        $stmt_items->bind_param("iiiisdi", $order_id, $user_id, $station_id, $service_id, $service_name, $service_price, $quantity);
+        if (!$stmt_items->execute()) {
+            throw new Exception("Failed to add item to order: " . $stmt_items->error);
+        }
+    }
+    $stmt_items->close();
+
+    // If everything was successful, commit the transaction
+    $conn->commit();
+
+    // Clean the output buffer and send success response
+    if (ob_get_level() > 0) ob_end_clean();
+    if (!headers_sent()) header("Content-Type: application/json");
+    echo json_encode(['status' => 'success', 'message' => 'Order created successfully!', 'order_id' => $order_id]);
+
+} catch (Exception $e) {
+    // If any step failed, roll back the transaction
+    $conn->rollback();
+    error_log("create_order.php: Transaction Error: " . $e->getMessage());
+    
+    // Clean the output buffer and send error response
+    if (ob_get_level() > 0) ob_end_clean();
+    if (!headers_sent()) header("Content-Type: application/json");
+    echo json_encode(['status' => 'error', 'message' => 'Order creation failed: ' . $e->getMessage()]);
+
+} finally {
+    // Close the connection if it's still open
+    if ($conn && $conn instanceof mysqli) {
+        $conn->close();
+    }
+    // Ensure the script exits cleanly
+    exit;
+}
+?>


### PR DESCRIPTION
Refactored CartProvider to support item quantities and improved cart management. Updated CartScreen to handle checkout, sending cart data to a new PHP API endpoint (create_order.php) for order creation. Adjusted navigation to pass user ID to CartScreen, and ensured service items include station ID. Added create_order.php to process incoming orders and insert them into the database.